### PR TITLE
Release v1.1-beta | Added option to save request results + bug fix

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,20 @@
+on:
+  push:
+    branches:
+      - dev
+      - main
+
+name: "Trigger: Push action"
+
+jobs:
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master
+        with:
+          severity: warning
+        env:
+          SHELLCHECK_OPTS: -e SC2086

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -4,7 +4,7 @@ on:
       - dev
       - main
 
-name: "Trigger: Push action"
+name: "ShellCheck"
 
 jobs:
   shellcheck:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # ipdbrep.sh
+
+[![ShellCheck](https://github.com/EarlyOwl/ipdbrep.sh/actions/workflows/shellcheck.yml/badge.svg?branch=main)](https://github.com/EarlyOwl/ipdbrep.sh/actions/workflows/shellcheck.yml)
+
 Report IPs to AbuseIPDB directly from the shell
 
 <img width="642" alt="Schermata 2022-09-27 alle 23 25 31" src="https://user-images.githubusercontent.com/49495410/192638837-9d0448a6-8583-4f12-82ba-9fda6346d485.png">
@@ -6,11 +9,9 @@ Report IPs to AbuseIPDB directly from the shell
 ## Contents
 - [What is this?](#what-is-this)
 - [How does it work?](#how-does-it-work)
-- [What do I need to make it work?](#what-do-i-need-to-make-it-work)
-- [Do I need to provide the API key each time?](#do-i-need-to-provide-the-api-key-each-time)
+- [Prerequisites](#prerequisites)
+- [Installation](#installation)
 - [How do I install Dialog?](how-do-i-install-dialog)
-- [How can I check if the script works without making an actual report?](#how-can-i-check-if-the-script-works-without-making-an-actual-report)
-- [The script is still not running](#the-script-is-still-not-running)
 - [Misc](#misc)
 
 ## What is this?
@@ -19,53 +20,66 @@ I created this script with the only purpose of submitting an IP address to the [
 ## How does it work?
 It makes a POST request to the AbuseIPDB **REPORT Endpoint**. As simple as that. You can find the API documentation [here](https://docs.abuseipdb.com/#report-endpoint).
 
-## What do I need to make it work?
+## Prerequisites
 - An AbuseIPDB **API key**, it's free. If you have an account already, you can create your API key from your [dashboard](https://www.abuseipdb.com/account/api).
 
 - The graphical interface is provided by Dialog, so you will need to [install it](#how-do-i-install-dialog) to make this script work.
 
-## Do I need to provide the API key each time?
-No, you can save your API key in a file named **api.txt** in the script running directory. Otherwise, you will be prompted each time you run the script.
-
-## How do I install Dialog?
-First, check if it's already installed on your system by running:
-```shell
+## Installation
+1. Make sure Dialog is available on your system by running:
+```
 dialog --version
 ```
-If not, you can run these commands based on your current OS / distro:
+If not, you can install it by following the instructions in the [next chapter](#how-do-i-install-dialog)
+
+2. Download ipdbrep.sh from the main branch to your local machine:
+```
+wget https://raw.githubusercontent.com/EarlyOwl/ipdbrep.sh/main/ipdbrep.sh
+```
+3. Make it executable:
+```
+chmod +x ipdbrep.sh
+```
+
+4. Run the script with:
+```
+./ipdbrep.sh
+```
+or, if you want every request output to be saved on a txt file and not only displayed on the screen:
+```
+./ipdbrep.sh save
+```
+
+That's it. Note that you will be prompted for your API key each time you execute the script. If you want to avoid this behavior, you can save your API key in a file named **api.txt** in the script's working directory.
+
+If you want to test the script, as per [documentation](https://docs.abuseipdb.com/#test-ip-addresses), you can simply report **127.0.0.1**. The output should be similar to this:
+```json
+  {
+    "data": {
+      "ipAddress": "127.0.0.1",
+      "abuseConfidenceScore": 0
+    }
+  }
+```
+
+## How do I install Dialog?
+If Dialog is not present on your machine, you can run those commands based on your current OS / distro to install it:
 
 ###### Ubuntu / Debian
-```shell
+```
 sudo apt-get update
 sudo apt-get install dialog
 ```
 
 ###### RHEL / CentOS
-```shell
+```
 sudo yum install dialog
 ```
 
 ###### MacOS
 Install it via [HomeBrew](https://docs.brew.sh/Installation) by running:
-```shell
+```
 brew install dialog
-```
-
-## How can I check if the script works without making an actual report?
-As per [documentation](https://docs.abuseipdb.com/#test-ip-addresses), you can simply report **127.0.0.1**. The output should be similar to this:
-```json
-  {
-    "data": {
-      "ipAddress": "127.0.0.1",
-      "abuseConfidenceScore": 52
-    }
-  }
-```
-
-## The script is still not running
-Make sure to make it executable:
-```shell
-chmod +x ipdbrep.sh
 ```
 
 ## Misc
@@ -73,8 +87,8 @@ chmod +x ipdbrep.sh
 ##### Can I contribute? Can I reuse all/part of this script for other purposes?
 Yes and yes.
 
-##### This sucks / You could have done X instead of X!
-I'm eager to learn, open an issue or a  pull request to suggest an improvement / fix.
-
 ##### Where I can find the report categories?
 You can find them [here](https://www.abuseipdb.com/categories).
+
+##### This sucks / You could have done X instead of X!
+I'm eager to learn, open an issue or a  pull request to suggest an improvement / fix.

--- a/ipdbrep.sh
+++ b/ipdbrep.sh
@@ -9,7 +9,7 @@ exec 3>&1; report_ip=$(dialog --title "[!] Input the required parameters" --back
 exec 3>&1; report_categories=$(dialog --title "[!] Input the required parameters" --backtitle "$current_version" --inputbox "Input the report category(ies). Comma separated for multiple categories" 0 0 2>&1 1>&3); exec 3>&-;
 exec 3>&1; report_comment=$(dialog --title "[!] Input the required parameters" --backtitle "$current_version" --inputbox "(OPTIONAL) Input the report comment. Max 1024 characters" 0 0 2>&1 1>&3); exec 3>&-;
 #Creating a temporary txt to store cURL results
-api_output=$(mktemp api_output.txt)
+api_output=$(mktemp)
 #Send POST request
 curl https://api.abuseipdb.com/api/v2/report \
   --data-urlencode "ip=$report_ip" \

--- a/ipdbrep.sh
+++ b/ipdbrep.sh
@@ -31,7 +31,7 @@ if [ $save_toggle = "save" ]; then
   output_file_name="$report_ip""_$current_timestamp.txt"
   #Pass the POST request output to the txt file
   echo $api_msgbox > $output_file_name
-  #
+  #Send a confirmation (showing the file name) to the user
   dialog --title "File created successfully" --backtitle "$current_version" --msgbox "Request output saved to file $output_file_name" 0 0
   #Finally invoke the function to ask if the user needs to input additional entries
   askforentry

--- a/ipdbrep.sh
+++ b/ipdbrep.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #Current version of the script, printed in the backtitle
-current_version="v1.0-beta"
+current_version="v1.1-beta"
 
 #Function to get parameters for the entry
 function addentry {
@@ -23,8 +23,22 @@ api_msgbox=$(cat $api_output)
 dialog --title "POST request output" --backtitle "$current_version" --msgbox "$api_msgbox" 0 0
 #Remove the temp file
 rm "$api_output"
-#Invoke the function to ask if the user needs to input additional entries
-askforentry
+#Check if the positional argument "save" was provided
+if [ $save_toggle = "save" ]; then
+  #If yes, save the output to a txt file in the current directory.
+  #The file name is made by the report ip + a timestamp in a ddmmyyyy_hhmmss format
+  current_timestamp=$(date +%d%m%Y_%H%M%S)
+  output_file_name="$report_ip""_$current_timestamp.txt"
+  #Pass the POST request output to the txt file
+  echo $api_msgbox > $output_file_name
+  #
+  dialog --title "File created successfully" --backtitle "$current_version" --msgbox "Request output saved to file $output_file_name" 0 0
+  #Finally invoke the function to ask if the user needs to input additional entries
+  askforentry
+else
+  #Invoke the function to ask if the user needs to input additional entries
+  askforentry
+fi
 }
 
 #Function to ask the user if he wants to input another entry
@@ -61,5 +75,7 @@ function checkapikey {
   fi
 }
 
+#Pass the first positional parameter (should be "save") into a variable
+save_toggle=$1
 #Invoke the first function
 checkapikey


### PR DESCRIPTION
- Added option to save the results of the requests on .txt files. It can be done by running the script with the _save_ parameter: `./ipdbrep.sh save`
- Fixed improper use of `mktemp`. Closes #1 
- Updated README.md
- Other minor fixes

Tested on:
- Ubuntu 20.04.4 LTS
- MacOS 12.6 Monterey